### PR TITLE
add clang-format Github action

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -1,0 +1,17 @@
+name: clang-format lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gnuradio/clang-format-lint-action@v0.5-4
+      with:
+        source: '.'
+        extensions: 'h,hpp,cpp,cc'
+        exclude: './python/guppi/bindings'

--- a/include/gnuradio/guppi/guppi_sink.h
+++ b/include/gnuradio/guppi/guppi_sink.h
@@ -21,7 +21,7 @@ namespace guppi {
  * \ingroup guppi
  *
  * \details
- * 
+ *
  * The GUPPI File Sink block writes single or dual-polarization channelized
  * 8-bit samples into a GUPPI raw file.
  */


### PR DESCRIPTION
This also fixes the formatting in a header file so that clang-format
passes.